### PR TITLE
Fix budget validator null handling

### DIFF
--- a/Backend/src/main/java/com/luckyseven/backend/domain/budget/validator/BudgetValidator.java
+++ b/Backend/src/main/java/com/luckyseven/backend/domain/budget/validator/BudgetValidator.java
@@ -29,7 +29,7 @@ public class BudgetValidator {
   public Budget validateBudgetExist(Long teamId) {
     return budgetRepository.findByTeamId(teamId)
         .orElseThrow(() ->
-            new CustomLogicException(ExceptionCode.TEAM_NOT_FOUND, "teamId: " + teamId)
+            new CustomLogicException(ExceptionCode.BUDGET_NOT_FOUND, "teamId: " + teamId)
         );
   }
 
@@ -52,7 +52,10 @@ public class BudgetValidator {
     }
   }
 
-  private void validateIsExchangedRequest(boolean isExchanged, BigDecimal exchangeRate) {
+  private void validateIsExchangedRequest(Boolean isExchanged, BigDecimal exchangeRate) {
+    if (isExchanged == null) {
+      return;
+    }
     if (Boolean.TRUE.equals(isExchanged) && exchangeRate == null) {
       throw new CustomLogicException(ExceptionCode.BAD_REQUEST, "환전 여부가 true인데 환율이 없습니다.");
     }

--- a/Backend/src/test/java/com/luckyseven/backend/domain/budget/validator/BudgetValidatorTests.java
+++ b/Backend/src/test/java/com/luckyseven/backend/domain/budget/validator/BudgetValidatorTests.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import com.luckyseven.backend.domain.budget.dao.BudgetRepository;
+import com.luckyseven.backend.domain.budget.dto.BudgetUpdateRequest;
 import com.luckyseven.backend.domain.budget.entity.Budget;
 import com.luckyseven.backend.domain.budget.entity.CurrencyCode;
 import com.luckyseven.backend.sharedkernel.exception.CustomLogicException;
@@ -65,6 +66,20 @@ class BudgetValidatorTests {
           budgetValidator.validateBudgetExist(teamId);
         }
     ).isInstanceOf(CustomLogicException.class);
+
+  }
+
+  @Test
+  @DisplayName("validateRequest(BudgetUpdateRequest)는 isExchanged가 null이어도 예외를 발생시키지 않는다")
+  void validateRequest_update_request_with_null_isExchanged_should_not_throw() {
+    BudgetUpdateRequest request = new BudgetUpdateRequest(
+        BigDecimal.valueOf(1000),
+        null,
+        null,
+        null
+    );
+
+    assertDoesNotThrow(() -> budgetValidator.validateRequest(request));
 
   }
 }


### PR DESCRIPTION
## Summary
- fix thrown exception type when budget is missing
- avoid NPE when `isExchanged` is null in budget validator
- add test to cover null `isExchanged` case

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6846532111ac8326b1ca0cea9c07e590